### PR TITLE
fix(VER-2554): Fix broken links on PyPi

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -27,7 +27,7 @@ xattr -dr com.apple.quarantine pocket-ic
 ```
 to bypass the developer verification from Apple.
 Alternatively, you can open the `pocket-ic` binary by right clicking on it in the Finder and selecting "Open" from the drop-down menu.
-Then, confirm opening this application by clicking "Open" again in the dialog that opened.
+Then, confirm opening this application by clicking "Open" in the dialog that pops up.
 
 By default, PocketIC will always search for the `pocket-ic` binary in the current directory; you can specify another path by setting the `POCKET_IC_BIN` environment variable, for example by prepending it to your `python3` invocation:
 

--- a/README.md
+++ b/README.md
@@ -28,22 +28,22 @@ assert(response == 'Hello, PocketIC!')
 
 ### Quickstart
 * Download the **PocketIC binary** for [Linux](https://download.dfinity.systems/ic/307d5847c1d2fe1f5e19181c7d0fcec23f4658b3/openssl-static-binaries/x86_64-linux/pocket-ic.gz) or [macOS](https://download.dfinity.systems/ic/307d5847c1d2fe1f5e19181c7d0fcec23f4658b3/openssl-static-binaries/x86_64-darwin/pocket-ic.gz), unzip and make it executable.
-* Leave the binary in your current working directory, or specify an alternative path with the `POCKET_IC_BIN` environment variable.
-* Run `python3 -m pip install pocket_ic` in your (virtual) environment to get the Python library. 
+* Leave the binary in your current working directory, or specify the path to the binary by setting the `POCKET_IC_BIN` environment variable before running your tests.
+* Run `pip3 install pocket_ic` in your (virtual) environment to get the Python library. 
 * Use `from pocket_ic import PocketIC` in your Python code and start testing!
 
-For a more detailed installation guide, see [INSTALLATION.md](INSTALLATION.md).
+For a more detailed installation guide, see [INSTALLATION.md](https://github.com/dfinity/pocketic-py/blob/main/INSTALLATION.md).
 
 ### Examples
 
-To see some working code, see the [examples](examples/) folder, or check out the [how to use this library](HOWTO.md) guide.
+To see some working code, see the [examples/](https://github.com/dfinity/pocketic-py/tree/main/examples) folder, or check out the [how to use this library](https://github.com/dfinity/pocketic-py/blob/main/HOWTO.md) guide.
 To run an example, clone this repo and run `python3 examples/counter_canister/counter_canister_test.py` from the repository's root directory.
 
 ## Documentation
-* [Why PocketIC](WHY.md)
-* [How to use this library](HOWTO.md)
+* [Why PocketIC](https://github.com/dfinity/pocketic-py/blob/main/WHY.md)
+* [How to use this library](https://github.com/dfinity/pocketic-py/blob/main/HOWTO.md)
 
 
 ## Contributing
-See [CONTRIBUTING.md](CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/dfinity/pocketic-py/blob/main/CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ assert(response == 'Hello, PocketIC!')
 ### Quickstart
 * Download the **PocketIC binary** for [Linux](https://download.dfinity.systems/ic/307d5847c1d2fe1f5e19181c7d0fcec23f4658b3/openssl-static-binaries/x86_64-linux/pocket-ic.gz) or [macOS](https://download.dfinity.systems/ic/307d5847c1d2fe1f5e19181c7d0fcec23f4658b3/openssl-static-binaries/x86_64-darwin/pocket-ic.gz), unzip and make it executable.
 * Leave the binary in your current working directory, or specify the path to the binary by setting the `POCKET_IC_BIN` environment variable before running your tests.
-* Run `pip3 install pocket_ic` in your (virtual) environment to get the Python library. 
+* Run `pip3 install pocket-ic` in your (virtual) environment to get the Python library. 
 * Use `from pocket_ic import PocketIC` in your Python code and start testing!
 
 For a more detailed installation guide, see [INSTALLATION.md](https://github.com/dfinity/pocketic-py/blob/main/INSTALLATION.md).

--- a/pocket_ic/pocket_ic_server.py
+++ b/pocket_ic/pocket_ic_server.py
@@ -34,12 +34,16 @@ class PocketICServer:
             bin_path = "./pocket-ic"
 
         if not os.path.isfile(bin_path):
-            raise FileNotFoundError(f"""Could not find the PocketIC binary. 
-                  
-I looked for it at "{bin_path}". You can specify another path 
-with the environment variable POCKET_IC_BIN (note that I run from "{os.getcwd()}").
+            raise FileNotFoundError(f"""Could not find the PocketIC binary.
 
-To get the PocketIC binary, see the instructions in the INSTALLATION.md file in the root of this repository.
+The PocketIC binary could not be found at "{bin_path}". Please specify the path to the binary with the POCKET_IC_BIN environment variable, \
+or place it in your current working directory (you are running PocketIC from {os.getcwd()}).
+
+Run the following commands to get the binary:
+    curl -sLO https://download.dfinity.systems/ic/307d5847c1d2fe1f5e19181c7d0fcec23f4658b3/openssl-static-binaries/$platform/pocket-ic.gz
+    gzip -d pocket-ic.gz
+    chmod +x pocket-ic
+where $platform is 'x86_64-linux' for Linux and 'x86_64-darwin' for Intel/rosetta-enabled Darwin.
 """)
 
         # Attempt to start the PocketIC server if it's not already running.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [tool.poetry]
 name = "pocket_ic"
-version = "1.0.0"
+version = "1.0.1"
 description = "A canister testing library"
 authors = [
     "The Internet Computer Project Developers <dept-testing_&_verification@dfinity.org>",
 ]
 license = "Apache-2.0"
+documentation = "https://github.com/dfinity/pocketic-py/blob/main/HOWTO.md"
 readme = "README.md"
 homepage = "https://github.com/dfinity/pocketic-py/"
 include = ["tests", "examples"]

--- a/tests/pocket_ic_test.py
+++ b/tests/pocket_ic_test.py
@@ -2,7 +2,6 @@
 
 import sys
 import os
-import time
 import unittest
 import ic
 


### PR DESCRIPTION
After some research I found that you cannot have relative links on PyPi, so there is no need to include them in the `pyproject.toml` file. We have to use absolute links instead, and refer to GitHub.