### PR TITLE
fix(PocketIC): Support for new server version 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## 2.0.1 - 2023-11-23
+
+### Added
+- Support for PocketIC server version 2.0.1
+
+
+### Changed
+- When the PocketIC binary is not found, the error now points to the PocketIC repo instead of the download link
+
+
+
 ## 2.0.0 - 2023-11-21
 
 ### Added

--- a/flake.lock
+++ b/flake.lock
@@ -37,25 +37,25 @@
     "pocket-ic-darwin-gz": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-gU4J+PPxCQGMmvN1QeIZRxd1NF4RxoIMOkikD3gd9d8=",
+        "narHash": "sha256-vIfxWmM5nOFel+vHhYnJ/ZCYvjcWxb5ZrjS5dpc6bpQ=",
         "type": "file",
-        "url": "https://download.dfinity.systems/ic/29ec86dc9f9ca4691d4d4386c8b2aa41e14d9d16/openssl-static-binaries/x86_64-darwin/pocket-ic.gz"
+        "url": "https://download.dfinity.systems/ic/69e1408347723dbaa7a6cd2faa9b65c42abbe861/openssl-static-binaries/x86_64-darwin/pocket-ic.gz"
       },
       "original": {
         "type": "file",
-        "url": "https://download.dfinity.systems/ic/29ec86dc9f9ca4691d4d4386c8b2aa41e14d9d16/openssl-static-binaries/x86_64-darwin/pocket-ic.gz"
+        "url": "https://download.dfinity.systems/ic/69e1408347723dbaa7a6cd2faa9b65c42abbe861/openssl-static-binaries/x86_64-darwin/pocket-ic.gz"
       }
     },
     "pocket-ic-linux-gz": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-z2+qgQsL02jpzPed+XarcYGZ4S4j/xEKkb84WIEuDa8=",
+        "narHash": "sha256-4XnFOZFapWFEfm7VrSWJeOcFvtRX76iaMfR2FeiIA78=",
         "type": "file",
-        "url": "https://download.dfinity.systems/ic/29ec86dc9f9ca4691d4d4386c8b2aa41e14d9d16/openssl-static-binaries/x86_64-linux/pocket-ic.gz"
+        "url": "https://download.dfinity.systems/ic/69e1408347723dbaa7a6cd2faa9b65c42abbe861/openssl-static-binaries/x86_64-linux/pocket-ic.gz"
       },
       "original": {
         "type": "file",
-        "url": "https://download.dfinity.systems/ic/29ec86dc9f9ca4691d4d4386c8b2aa41e14d9d16/openssl-static-binaries/x86_64-linux/pocket-ic.gz"
+        "url": "https://download.dfinity.systems/ic/69e1408347723dbaa7a6cd2faa9b65c42abbe861/openssl-static-binaries/x86_64-linux/pocket-ic.gz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,11 +5,11 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     pocket-ic-darwin-gz = {
-      url = "https://download.dfinity.systems/ic/29ec86dc9f9ca4691d4d4386c8b2aa41e14d9d16/openssl-static-binaries/x86_64-darwin/pocket-ic.gz";
+      url = "https://download.dfinity.systems/ic/69e1408347723dbaa7a6cd2faa9b65c42abbe861/openssl-static-binaries/x86_64-darwin/pocket-ic.gz";
       flake = false;
     };
     pocket-ic-linux-gz = {
-      url = "https://download.dfinity.systems/ic/29ec86dc9f9ca4691d4d4386c8b2aa41e14d9d16/openssl-static-binaries/x86_64-linux/pocket-ic.gz";
+      url = "https://download.dfinity.systems/ic/69e1408347723dbaa7a6cd2faa9b65c42abbe861/openssl-static-binaries/x86_64-linux/pocket-ic.gz";
       flake = false;
     };
   };

--- a/pocket_ic/pocket_ic.py
+++ b/pocket_ic/pocket_ic.py
@@ -316,22 +316,6 @@ class PocketIC:
         Returns:
             ic.Principal: the ID of the created canister
         """
-
-        if canister_id:
-            subnet_id = self.get_subnet(canister_id)
-            if not subnet_id:
-                raise ValueError("Canister ID not contained in any subnet")
-
-            topology = {k.to_str(): v for k, v in self.topology.items()}
-            subnet_kind = topology[subnet_id.to_str()]
-            if (
-                subnet_kind == SubnetKind.APPLICATION
-                or subnet_kind == SubnetKind.SYSTEM
-            ):
-                raise ValueError(
-                    "Creating a canister with ID is only supported on Bitcoin, Fiduciary, II, SNS and NNS subnets"
-                )
-
         record = Types.Record(
             {
                 "settings": Types.Opt(

--- a/pocket_ic/pocket_ic_server.py
+++ b/pocket_ic/pocket_ic_server.py
@@ -42,11 +42,7 @@ class PocketICServer:
 The PocketIC binary could not be found at "{bin_path}". Please specify the path to the binary with the POCKET_IC_BIN environment variable, \
 or place it in your current working directory (you are running PocketIC from {os.getcwd()}).
 
-Run the following commands to get the binary:
-    curl -sLO https://download.dfinity.systems/ic/29ec86dc9f9ca4691d4d4386c8b2aa41e14d9d16/openssl-static-binaries/x86_64-$platform/pocket-ic.gz
-    gzip -d pocket-ic.gz
-    chmod +x pocket-ic
-where $platform is 'linux' for Linux and 'darwin' for Intel/rosetta-enabled Darwin.
+To download the binary, please visit https://github.com/dfinity/pocketic.
 """
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pocket_ic"
-version = "2.0.0"
+version = "2.0.1"
 description = "PocketIC: A Canister Smart Contract Testing Platform"
 authors = [
     "The Internet Computer Project Developers <dept-testing_&_verification@dfinity.org>",


### PR DESCRIPTION
- Support for PocketIC server version 2.0.1
- When the PocketIC binary is not found, the error now points to the PocketIC repo instead of the download link