### PR TITLE
chore: replace await_ingress_message by tick and ingress_status

### DIFF
--- a/pocket_ic/pocket_ic.py
+++ b/pocket_ic/pocket_ic.py
@@ -422,9 +422,24 @@ class PocketIC:
         submit_ingress_message = self._instance_post(
             "update/submit_ingress_message", body
         )
-        ok = self._get_ok(submit_ingress_message)
-        result = self._instance_post("update/await_ingress_message", ok)
-        return self._get_ok_data(result)
+        msg_id = self._get_ok(submit_ingress_message)
+        rounds = 0
+        while True:
+          self.tick()
+          rounds += 1
+          result = self._ingress_status(msg_id)
+          if result:
+            return self._get_ok_data(result)
+          if rounds >= 100:
+            msg = f"PocketIC did not complete the update call within 100 rounds"
+            raise ValueError(msg)
+
+    def _ingress_status(self, msg_id):
+        body = {
+            "raw_message_id": msg_id,
+            "raw_caller": None,
+        }
+        return self._instance_post("read/ingress_status", body)
 
     def _get_ok(self, request_result):
         if "Ok" in request_result:


### PR DESCRIPTION
This PR replaces calls to the `await_ingress_message` endpoint of the PocketIC server by calls to the endpoints `tick` and `ingress_status` in a loop: the motivation for this change is to deprecate the (potentially long-running) endpoint `await_ingress_message` of the PocketIC server.